### PR TITLE
Add new link for how to create an Atlas account

### DIFF
--- a/MultiplatformDemoWithSync/README.md
+++ b/MultiplatformDemoWithSync/README.md
@@ -8,7 +8,7 @@ The demo demonstrates [Sync](https://www.mongodb.com/realm/mobile/sync) capabili
 
 ## 1 - Create a Realm Sync App on MongoDB Atlas
 
-- Follow the tutorial at https://docs.mongodb.com/realm/tutorial/realm-app/#a.-create-an-atlas-account or watch the screencast https://www.youtube.com/watch?v=lqo0Yf7lnyg
+- Follow the tutorial at https://www.mongodb.com/docs/atlas/tutorial/create-atlas-account/ or watch the screencast https://www.youtube.com/watch?v=lqo0Yf7lnyg
 
 - Replace the App identifier and the created user/password in [shared/src/commonMain/kotlin/io/realm/kotlin/demo/util/Constants.kt](./shared/src/commonMain/kotlin/io/realm/kotlin/demo/util/Constants.kt)
 

--- a/MultiplatformDemoWithSync/shared/src/commonMain/kotlin/io/realm/kotlin/demo/util/Constants.kt
+++ b/MultiplatformDemoWithSync/shared/src/commonMain/kotlin/io/realm/kotlin/demo/util/Constants.kt
@@ -18,7 +18,7 @@ package io.realm.kotlin.demo.util
 /**
  * Replace with your own App's credentials to enable Sync.
  * To setup the Realm Sync App on MongoDB Atlas follow the steps here
- * https://docs.mongodb.com/realm/tutorial/realm-app/ or watch the video tutorial https://www.youtube.com/watch?v=lqo0Yf7lnyg
+ * https://www.mongodb.com/docs/atlas/tutorial/create-atlas-account/ or watch the video tutorial https://www.youtube.com/watch?v=lqo0Yf7lnyg
  */
 object Constants {
     val MONGODB_REALM_APP_ID = "[REPLACE ME]"


### PR DESCRIPTION
Using the old link gave you a 404 error, don't know precisely how the previous guide looked like but I assume that the new link I provided will be working fine